### PR TITLE
Fix typo of fork (Slack -> Discord)

### DIFF
--- a/discovery.json
+++ b/discovery.json
@@ -1,8 +1,8 @@
 {
     "botman/driver-config": [
-        "stubs/slack.php"
+        "stubs/discord.php"
     ],
     "botman/driver": [
-        "BotMan\\Drivers\\Slack\\SlackDriver"
+        "BotMan\\Drivers\\Discord\\DiscordDriver"
     ]
 }


### PR DESCRIPTION
Because of unable to discover the provider.